### PR TITLE
Fix texture rendering

### DIFF
--- a/build_mjcf.py
+++ b/build_mjcf.py
@@ -96,6 +96,7 @@ def build() -> mjcf.RootElement:
     cubelet_default = root.default.add("default", dclass="cubelet")
     cubelet_default.geom.type = "mesh"
     cubelet_default.geom.mesh = "cubelet"
+    cubelet_default.geom.quat = (1, 0, 0, 1)
     cubelet_default.geom.condim = 1
     cubelet_default.joint.type = "ball"
     cubelet_default.joint.armature = 1e-4

--- a/cube_3x3x3.xml
+++ b/cube_3x3x3.xml
@@ -12,7 +12,7 @@
     <motor ctrlrange="-0.05 0.05"/>
     <default class="cubelet">
       <joint type="ball" armature="0.0001" damping="0.0005" frictionloss="0.001"/>
-      <geom type="mesh" condim="1" mesh="cubelet"/>
+      <geom type="mesh" condim="1" quat="1 0 0 1" mesh="cubelet"/>
     </default>
     <default class="core">
       <geom type="sphere" contype="0" conaffinity="0" group="4" size="0.01"/>


### PR DESCRIPTION
Copying MuJoCo's [fix](https://github.com/google-deepmind/mujoco/commit/f0608648cbc17bcb6f0387dcbb0d550a9c7a2882).

> This solves the texture rendering issue with the Rubik's cube. The texture were specified with respect to the incorrect frame, so a default rotation of (0, 0, pi/2) is now applied to the model file.

This fixes #1.